### PR TITLE
feat: 新增 dark mode 支援

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="en" data-theme="light">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
@@ -11,6 +11,7 @@
     <link rel="stylesheet" href="style.css" />
   </head>
   <body>
+    <button class="theme-toggle" id="themeToggle" aria-label="切換深色模式">🌙</button>
     <div class="page-container">
       <!-- Left Hero Section -->
       <section class="hero-section">

--- a/main.js
+++ b/main.js
@@ -1,4 +1,40 @@
 document.addEventListener("DOMContentLoaded", () => {
+  // ── Dark Mode Toggle ──────────────────────────────────
+  const html = document.documentElement;
+  const toggleBtn = document.getElementById("themeToggle");
+
+  // 決定初始主題：localStorage > 系統偏好 > 預設 light
+  const savedTheme = localStorage.getItem("theme");
+  const prefersDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
+  const initialTheme = savedTheme || (prefersDark ? "dark" : "light");
+
+  function applyTheme(theme) {
+    html.setAttribute("data-theme", theme);
+    toggleBtn.textContent = theme === "dark" ? "☀️" : "🌙";
+    toggleBtn.setAttribute(
+      "aria-label",
+      theme === "dark" ? "切換淺色模式" : "切換深色模式",
+    );
+    localStorage.setItem("theme", theme);
+  }
+
+  applyTheme(initialTheme);
+
+  toggleBtn.addEventListener("click", () => {
+    const current = html.getAttribute("data-theme");
+    applyTheme(current === "dark" ? "light" : "dark");
+  });
+
+  // 監聽系統主題變更（僅在使用者未手動設定時生效）
+  window
+    .matchMedia("(prefers-color-scheme: dark)")
+    .addEventListener("change", (e) => {
+      if (!localStorage.getItem("theme")) {
+        applyTheme(e.matches ? "dark" : "light");
+      }
+    });
+  // ─────────────────────────────────────────────────────
+
   const form = document.getElementById("createAccountForm");
 
   form.addEventListener("submit", (e) => {

--- a/style.css
+++ b/style.css
@@ -165,8 +165,6 @@ h1 {
   font-size: 26px;
   margin-bottom: 40px;
   text-align: center;
-  color: var(--text-primary);
-  transition: color 0.3s ease;
 }
 
 .form-group {
@@ -296,17 +294,6 @@ h1 {
   width: 40px;
   height: 40px;
   margin-right: 15px;
-  transition: filter 0.3s ease;
-}
-
-[data-theme="dark"] .btn-social img {
-  filter: invert(1) brightness(0.85);
-}
-
-@media (prefers-color-scheme: dark) {
-  :root:not([data-theme="light"]) .btn-social img {
-    filter: invert(1) brightness(0.85);
-  }
 }
 
 .copyright {

--- a/style.css
+++ b/style.css
@@ -165,6 +165,8 @@ h1 {
   font-size: 26px;
   margin-bottom: 40px;
   text-align: center;
+  color: var(--text-primary);
+  transition: color 0.3s ease;
 }
 
 .form-group {
@@ -294,6 +296,17 @@ h1 {
   width: 40px;
   height: 40px;
   margin-right: 15px;
+  transition: filter 0.3s ease;
+}
+
+[data-theme="dark"] .btn-social img {
+  filter: invert(1) brightness(0.85);
+}
+
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme="light"]) .btn-social img {
+    filter: invert(1) brightness(0.85);
+  }
 }
 
 .copyright {

--- a/style.css
+++ b/style.css
@@ -1,7 +1,7 @@
 @import url("https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;600&family=Roboto:wght@400&display=swap");
 
 :root {
-  /* Colors */
+  /* Colors - Light Mode */
   --bg-primary: rgba(230, 243, 255, 0.75);
   --bg-content: #fcfeff;
   --accent-yellow: #f9ed32;
@@ -11,6 +11,12 @@
   --text-secondary: #7c838a;
   --text-muted: #b0bac3;
   --input-bg: rgba(176, 186, 195, 0.4);
+  --input-placeholder: rgba(0, 0, 0, 0.5);
+  --input-focus-bg: rgba(176, 186, 195, 0.6);
+  --social-hover-bg: rgba(124, 131, 138, 0.05);
+  --shadow-color: rgba(0, 0, 0, 0.1);
+  --toggle-bg: #e2e8f0;
+  --toggle-icon: "🌙";
 
   /* Typography */
   --font-primary: "Poppins", sans-serif;
@@ -22,6 +28,40 @@
   --radius-small: 10px;
   --radius-social: 15px;
   --max-content-width: 600px;
+}
+
+/* Dark Mode Variables */
+[data-theme="dark"] {
+  --bg-primary: #1a1f2e;
+  --bg-content: #242938;
+  --text-primary: #e8eaf0;
+  --text-secondary: #9ba3af;
+  --text-muted: #6b7280;
+  --input-bg: rgba(255, 255, 255, 0.08);
+  --input-placeholder: rgba(255, 255, 255, 0.35);
+  --input-focus-bg: rgba(255, 255, 255, 0.13);
+  --social-hover-bg: rgba(255, 255, 255, 0.06);
+  --shadow-color: rgba(0, 0, 0, 0.4);
+  --toggle-bg: #374151;
+  --toggle-icon: "☀️";
+}
+
+/* System-level dark mode preference (default before JS loads) */
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme="light"]) {
+    --bg-primary: #1a1f2e;
+    --bg-content: #242938;
+    --text-primary: #e8eaf0;
+    --text-secondary: #9ba3af;
+    --text-muted: #6b7280;
+    --input-bg: rgba(255, 255, 255, 0.08);
+    --input-placeholder: rgba(255, 255, 255, 0.35);
+    --input-focus-bg: rgba(255, 255, 255, 0.13);
+    --social-hover-bg: rgba(255, 255, 255, 0.06);
+    --shadow-color: rgba(0, 0, 0, 0.4);
+    --toggle-bg: #374151;
+    --toggle-icon: "☀️";
+  }
 }
 
 * {
@@ -38,6 +78,7 @@ body {
   align-items: center;
   justify-content: center;
   overflow-x: hidden;
+  transition: background-color 0.3s ease;
 }
 
 .page-container {
@@ -47,10 +88,13 @@ body {
   max-height: 100vh;
   background-color: var(--bg-content);
   display: flex;
-  box-shadow: 0 50px 100px -20px rgba(0, 0, 0, 0.1);
+  box-shadow: 0 50px 100px -20px var(--shadow-color);
   position: relative;
   border-radius: var(--radius-large);
   overflow: hidden;
+  transition:
+    background-color 0.3s ease,
+    box-shadow 0.3s ease;
 }
 
 /* Hero Section (Left) */
@@ -145,15 +189,18 @@ h1 {
   font-family: var(--font-primary);
   font-size: 20px;
   outline: none;
-  transition: background-color 0.3s ease;
+  color: var(--text-primary);
+  transition:
+    background-color 0.3s ease,
+    color 0.3s ease;
 }
 
 .form-group input::placeholder {
-  color: rgba(0, 0, 0, 0.5);
+  color: var(--input-placeholder);
 }
 
 .form-group input:focus {
-  background-color: rgba(176, 186, 195, 0.6);
+  background-color: var(--input-focus-bg);
 }
 
 .btn-primary {
@@ -240,7 +287,7 @@ h1 {
 }
 
 .btn-social:hover {
-  background-color: rgba(124, 131, 138, 0.05);
+  background-color: var(--social-hover-bg);
 }
 
 .btn-social img {
@@ -255,6 +302,33 @@ h1 {
   font-size: 20px;
   color: var(--text-secondary);
   margin-top: 60px;
+}
+
+/* Dark Mode Toggle Button */
+.theme-toggle {
+  position: fixed;
+  top: 20px;
+  right: 20px;
+  width: 48px;
+  height: 48px;
+  border-radius: 50%;
+  border: none;
+  background-color: var(--toggle-bg);
+  cursor: pointer;
+  font-size: 22px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+  box-shadow: 0 2px 10px var(--shadow-color);
+  transition:
+    background-color 0.3s ease,
+    transform 0.2s ease,
+    box-shadow 0.3s ease;
+}
+
+.theme-toggle:hover {
+  transform: scale(1.1);
 }
 
 /* Responsive adjustments */


### PR DESCRIPTION
## 解決 Issue

closes #1

## 變更內容

### `style.css`
- 新增完整的 dark mode CSS 變數（`[data-theme="dark"]` 選擇器）
- 新增 `@media (prefers-color-scheme: dark)` 自動偵測系統主題
- 新增浮動切換按鈕 `.theme-toggle` 樣式
- 所有顏色改用 CSS 變數，支援平滑過渡動畫（0.3s ease）

### `index.html`
- `<html>` 標籤加入 `data-theme="light"` 屬性
- 新增右上角浮動切換按鈕（🌙 / ☀️）

### `main.js`
- 新增 dark mode toggle 邏輯
- 偏好儲存至 `localStorage`，重整頁面後自動套用
- 監聽系統主題變更（`prefers-color-scheme`），未手動設定時自動跟隨

## Dark Mode 配色

| Token | Light | Dark |
|---|---|---|
| `--bg-primary` | `rgba(230,243,255,0.75)` | `#1a1f2e` |
| `--bg-content` | `#fcfeff` | `#242938` |
| `--text-primary` | `#000000` | `#e8eaf0` |
| `--text-secondary` | `#7c838a` | `#9ba3af` |
| `--input-bg` | `rgba(176,186,195,0.4)` | `rgba(255,255,255,0.08)` |